### PR TITLE
Fix strings not working correctly when appearing alongside other data structures

### DIFF
--- a/src/hiccup.js
+++ b/src/hiccup.js
@@ -60,7 +60,7 @@ const htmlDataStructureToString = (tag, attrs, ...value) => {
       })
       .map(x => {
         if (typeof x === 'string') {  
-          return val
+          return x
         }
       
         return htmlDataStructureToString(...x)


### PR DESCRIPTION
When rendering a data structure like:

```js
const boldMonth = ['p', {},
  ['b', {}, 'February'],
  ' 15th, 2022'
];
```

some unusual content was added to the dom. This is because the entire array of values was being included instead of just the current iteration in the map.